### PR TITLE
downgrading docker container 

### DIFF
--- a/main
+++ b/main
@@ -11,7 +11,7 @@ NUMFILES=`python numfiles.py`
 echo "there are $NUMFILES files" 
 echo "starting main"
 
-singularity exec -e docker://brainlife/pythonvtk ./main.py
+singularity exec -e docker://brainlife/pythonvtk:1.2 ./main.py
 
 count=$(ls surfaces/* | wc -l)
 if [ "$count" == "$NUMFILES" ] 

--- a/main
+++ b/main
@@ -11,7 +11,7 @@ NUMFILES=`python numfiles.py`
 echo "there are $NUMFILES files" 
 echo "starting main"
 
-singularity exec -e docker://brainlife/pythonvtk:1.2 ./main.py
+singularity exec -e docker://brainlife/pythonvtk:1.1 ./main.py
 
 count=$(ls surfaces/* | wc -l)
 if [ "$count" == "$NUMFILES" ] 


### PR DESCRIPTION
The latest version of pythonvtk container (1.2) comes with the latest version of vtk which no longer provides vtk.vtkNIFTIImageReader(). 

We should set container version when we invoke singularity anyways.

Also, BL seems to be pointing to master branch of this App. Can you create a new branch and point BL App to it?